### PR TITLE
datetime: default date when intervals are in use

### DIFF
--- a/src/anypicker-datetime.js
+++ b/src/anypicker-datetime.js
@@ -288,6 +288,16 @@ AnyPicker.prototype = $.extend(AnyPicker.prototype, {
 		else
 		{
 			apo.tmp.selectedDate = new Date($.AnyPicker.extra.dToday);
+			
+			if (apo.setting.intervals.h !== undefined && apo.tmp.selectedDate.getHours() % apo.setting.intervals.h !== 0) {
+				apo.tmp.selectedDate.setHours(0);
+			}
+			if (apo.setting.intervals.m !== undefined && apo.tmp.selectedDate.getMinutes() % apo.setting.intervals.m !== 0) {
+				apo.tmp.selectedDate.setMinutes(0);
+			}
+			if (apo.setting.intervals.s !== undefined && apo.tmp.selectedDate.getSeconds() % apo.setting.intervals.s !== 0) {
+				apo.tmp.selectedDate.setSeconds(0);
+			}
 		}
 	},
 


### PR DESCRIPTION
The timepicker displays today's date&time as default when its initial value is empty.
When using intervals for hours/minutes/seconds - today's time might not comply with these intervals, which leads to unexpected behaviors.

E.g. configure AnyPicker to use `intervals: { h: 1, m: 15 }`, and assume that the time now is 15:23.
The previous behavior will lead to bugs since the minutes value is not 0/15/30/45.

I suggest that the timepicker will use zeros when the hours/minutes/seconds value doesn't fit the interval.
